### PR TITLE
Memory caching

### DIFF
--- a/src/app/gamedetails/GameDetailsPage.tsx
+++ b/src/app/gamedetails/GameDetailsPage.tsx
@@ -1,10 +1,12 @@
 import React from "react";
 import { ObjectId } from "mongodb";
 import GameDetails from "@/components/GameDetails";
+import { GameDetailsPageProps } from "@/types/gameDetails";
+
+import { mergeArenaInfo } from "@/lib/mergeGameData";
+import { getUpcomingGames } from "@/lib/staticCache";
 import { connectToDatabase } from "@/lib/mongodb";
 import { getTeamLogo } from "@/lib/teamNameMap";
-import { GameDetailsPageProps } from "@/types/gameDetails";
-import { mergeArenaInfo } from "@/lib/mergeGameData";
 
 
 export default async function GameDetailsPage({ id }: GameDetailsPageProps) {
@@ -17,8 +19,9 @@ export default async function GameDetailsPage({ id }: GameDetailsPageProps) {
   if (!baseGameRecord) {
     return <p className="text-center text-gray-600">No game data available.</p>;
   }
-
-  const mergedGameRecord = await mergeArenaInfo(baseGameRecord, db);
+  
+  const upcomingGames = await getUpcomingGames();
+  const mergedGameRecord = await mergeArenaInfo(baseGameRecord, upcomingGames);
   mergedGameRecord._id = mergedGameRecord._id.toString(); // plain object ID for JSON serialization.. sucks i guess
 
   const { home_team, away_team, commence_time } = mergedGameRecord;

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -17,6 +17,20 @@ export default async function Home({
 }: {
   searchParams: Promise<{ [key: string]: string | string[] | undefined }>;
 }) {
+  function deduplicateGames(games: any[]) {
+    const seen = new Set();
+    const uniqueGames: any[] = [];
+  
+    for (const game of games) {
+      const key = `${game.home_team}-${game.away_team}-${game.commence_time}`;
+      if (!seen.has(key)) {
+        seen.add(key);
+        uniqueGames.push(game);
+      }
+    }
+    return uniqueGames;
+  }
+  
   const sp = await searchParams;
   const { tab, tz } = sp;
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -6,7 +6,7 @@ import { formatInTimeZone } from "date-fns-tz";
 import { addDays } from "date-fns";
 
 import { mergeArenaInfo } from "@/lib/mergeGameData"; 
-import { getEvResults } from "@/lib/staticCache";
+import { getEvResults, getUpcomingGames } from "@/lib/staticCache";
 import { getTeamLogo } from "@/lib/teamNameMap";
 
 import GamesGrid from "@/components/GamesGrid";
@@ -43,6 +43,7 @@ export default async function Home({
   const startTomorrowStr = formatInTimeZone(tomorrow, timeZone, "yyyy-MM-dd'T'00:00:00XXX");
   const endTomorrowStr = formatInTimeZone(tomorrow, timeZone, "yyyy-MM-dd'T'23:59:59XXX");
   const sevenDaysLater = addDays(now, 7);
+  const upcomingGames = await getUpcomingGames();
 
   const evResults = await getEvResults();
   let games: any[] = [];
@@ -91,7 +92,7 @@ export default async function Home({
   games = deduplicateGames(games);
   games = await Promise.all(
     games.map(async (game) => {
-      return await mergeArenaInfo(game, { collection: () => ({ findOne: async () => null }) }); 
+      return await mergeArenaInfo(game, upcomingGames);
     })
   );
   games = JSON.parse(JSON.stringify(games)); // for json serialization

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -82,6 +82,8 @@ export default async function Home({
     // For upcoming, filter games from now until seven days later.
     games = evResults.filter((game) => {
       const gameTime = new Date(game.commence_time);
+      // gameTime > new Date(endTodayStr) && gameTime <= sevenDaysLater  if we want to include only games after today
+      // but for now to include all games within the next 7 days from now, we can use the following condition:
       return gameTime >= now && gameTime <= sevenDaysLater;
     });
   }

--- a/src/components/GameResults.tsx
+++ b/src/components/GameResults.tsx
@@ -1,9 +1,7 @@
-import { connectToDatabase } from "@/lib/mongodb";
+import { getGames } from "@/lib/staticCache";
 
 export default async function GameResults() {
-  const { db } = await connectToDatabase();
-  const results = await db.collection("games").find({}).toArray();
-
+  const results = await getGames();
   return (
     <div
       className="p-4"

--- a/src/lib/mergeGameData.ts
+++ b/src/lib/mergeGameData.ts
@@ -4,7 +4,7 @@
  * 
  * Finds games in upcoming_games with a game_time within 3 hours of commence_time.
  */
-export async function mergeArenaInfo(baseGame: any, db: any): Promise<any> {
+export async function mergeArenaInfo(baseGame: any, upcomingGames: any[]): Promise<any> {
   const { home_team, away_team, commence_time } = baseGame;
 
   const baseGameTime = new Date(commence_time);
@@ -12,15 +12,12 @@ export async function mergeArenaInfo(baseGame: any, db: any): Promise<any> {
   const windowStart = new Date(baseGameTime.getTime() - timeWindowMs);
   const windowEnd = new Date(baseGameTime.getTime() + timeWindowMs);
 
-  const match = await db.collection("upcoming_games").findOne({
-    game_time: { $gte: windowStart.toISOString(), $lte: windowEnd.toISOString() },
-    home_team: { $regex: home_team, $options: "i" },
-    away_team: { $regex: away_team, $options: "i" }
+  const match = upcomingGames.find((g) => {
+    const gameTime = new Date(g.game_time);
+    return (gameTime >= windowStart && gameTime <= windowEnd && g.home_team.toLowerCase() === home_team.toLowerCase() &&
+      g.away_team.toLowerCase() === away_team.toLowerCase()
+    );
   });
 
-  if (match?.arena) {
-    return { ...baseGame, arena: match.arena };
-  }
-
-  return { ...baseGame, arena: "Location not available" };
+  return { ...baseGame, arena: match?.arena ?? "Location not available" };
 }

--- a/src/lib/redis.ts
+++ b/src/lib/redis.ts
@@ -1,4 +1,0 @@
-import Redis from "ioredis";
-
-const redis = new Redis(process.env.REDIS_URL || "redis://localhost:6379");
-export default redis;

--- a/src/lib/staticCache.ts
+++ b/src/lib/staticCache.ts
@@ -1,0 +1,47 @@
+import { connectToDatabase } from './mongodb';
+
+let evResultsCache: { data: any[]; timestamp: number } | null = null;
+let upcomingGamesCache: any[] | null = null;
+let gamesCache: any[] | null = null;
+
+// TTL for ev_results, 2 hours
+const TTL = 2 * 60 * 60 * 1000;
+
+/**
+ * Returns the ev_results data from MongoDB, cached in memory.
+ * Cache is invalidated after TTL.
+ */
+export async function getEvResults() {
+  const now = Date.now();
+  if (evResultsCache && now - evResultsCache.timestamp < TTL) {
+    return evResultsCache.data;
+  }
+  const { db } = await connectToDatabase();
+  const data = await db.collection("ev_results").find({}).toArray();
+  evResultsCache = { data, timestamp: now };
+  return data;
+}
+
+/**
+ * Returns the upcoming_games data from MongoDB, cached permanently per instance.
+ */
+export async function getUpcomingGames() {
+  if (upcomingGamesCache) {
+    return upcomingGamesCache;
+  }
+  const { db } = await connectToDatabase();
+  upcomingGamesCache = await db.collection("upcoming_games").find({}).toArray();
+  return upcomingGamesCache;
+}
+
+/**
+ * Returns the games data from MongoDB, cached in memory.
+ */
+export async function getGames() {
+  if (gamesCache) {
+    return gamesCache;
+  }
+  const { db } = await connectToDatabase();
+  gamesCache = await db.collection("games").find({}).toArray();
+  return gamesCache;
+}


### PR DESCRIPTION
Swapped out Redis caching in favor of direct in-memory caching using instance variable. Simplifies logic as Redis is overkill at the moment.

- getEvResults() uses TTL-based cache (~2 hours)
- getUpcomingGames() and getGames() are cached permanently per instance
- mergeArenaInfo() refactored to use in-memory upcoming games data instead of querying MongoDB every time
- Deduplication added to avoid multiple duplicate game entries
- Filtering logic had to also be updated to reflect not fetching from mongodb always

### **Why not Redis?**
Cold starts are already minimal with in-memory caching. And again, Redis adds complexity for marginal gains at the moment. Arcjet can be added later if we need globally consistent caching or more granular invalidation beyond in-memory TTL.

